### PR TITLE
Feature/pre build credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ If the env var **GITLAB_CI** is set and the branch name (**CI_BUILD_REF_NAME** e
 - **upload**: URL of the repository where we want to use to upload the packages.
 - **upload_only_when_stable**: Will try to upload only if the channel is the stable channel
 - **build_types**: List containing specific build types. Default ["Release", "Debug"]
-- **check_credentials_before**: Check user credentials before to build when upload is required. Default [False]
+- **skip_check_credentials**: Conan will check the user credentials before building the packages. Default [False]
 
 Upload related parameters:
 

--- a/README.md
+++ b/README.md
@@ -562,6 +562,24 @@ Upload related parameters:
 - **channel**: Channel where your packages will be uploaded if previous parameter doesn't match
 
 
+## Complete ConanMultiPackager methods reference:
+
+- **add_common_builds(shared_option_name=None, pure_c=True, dll_with_static_runtime=False)**: Generate a set of package configurations and add them to the
+  list of packages that will be created.
+
+    - **shared_option_name**: If given, ConanMultiPackager will add different configurations for -o shared=True and -o shared=False.
+    - **pure_c**: ConanMultiPackager won't generate different builds for the **libstdc++** c++ standard library, because it is a pure C library.
+    - **dll_with_static_runtime**: generate also build for "MT" runtime when the library is shared.
+
+- **login(remote_name, user=None, password=None, force=False)**: Performs a `conan user` command in the specified remote. If `force` the login will be called
+ every time, otherwise, for the same remote, ConanMultiPackager will call `conan user` only once even with multiple calls to the login() method.
+
+- **add(settings=None, options=None, env_vars=None, build_requires=None)**: Add a new build configuration, so a new binary package will be built for the specified configuration.
+
+- **run()**: Run the builds (Will invoke conan create for every specified configuration)
+
+- **upload_packages()**: Called automatically by "run()" when upload is enabled. Can be called explicitly.
+
 ## Environment configuration
 
 You can also use environment variables to change the behavior of ConanMultiPackager, so that you don't pass parameters to the ConanMultiPackager constructor.

--- a/conan/test/packager_test.py
+++ b/conan/test/packager_test.py
@@ -365,6 +365,30 @@ class AppTest(unittest.TestCase):
                          'conan upload Hello/0.1@pepe/%s --retry 3 --all '
                          '--force --confirm -r=upload_repo' % channel)
 
+    def test_login(self):
+        runner = MockRunner()
+        builder = ConanMultiPackager(username="pepe", channel="testing",
+                                     reference="Hello/0.1", password="password",
+                                     upload="myurl", visual_versions=[], gcc_versions=[],
+                                     apple_clang_versions=[],
+                                     runner=runner)
+
+        builder.login("Myremote", "myuser", "mypass", force=False)
+        self.assertIn('conan user myuser -p="mypass" -r=Myremote', runner.calls[-1])
+        runner.calls = []
+        # Already logged, not call conan user again
+        builder.login("Myremote", "myuser", "mypass", force=False)
+        self.assertEquals(len(runner.calls), 0)
+        # Already logged, but forced
+        runner.calls = []
+        builder.login("Myremote", "myuser", "mypass", force=True)
+        self.assertEquals(len(runner.calls), 1)
+
+        # Default users/pass
+        runner.calls = []
+        builder.login("Myremote2")
+        self.assertIn('conan user pepe -p="password" -r=Myremote2', runner.calls[-1])
+
     def test_check_credentials(self):
 
         class PlatformInfoMock(object):
@@ -378,12 +402,9 @@ class AppTest(unittest.TestCase):
                                      upload="myurl", visual_versions=[], gcc_versions=[],
                                      apple_clang_versions=[],
                                      runner=runner,
-                                     platform_info=PlatformInfoMock(),
-                                     check_credentials_before=True)
+                                     platform_info=PlatformInfoMock())
         builder.add_common_builds()
         builder.run()
-
-        print(runner.calls)
 
         # When activated, check credentials before to create the profiles
         self.assertEqual(runner.calls[0:2], ['conan remote add upload_repo myurl',
@@ -396,9 +417,12 @@ class AppTest(unittest.TestCase):
         else:
             channel = "testing"
 
-        self.assertEqual(runner.calls[-2:],
-                         ['conan user pepe -p="password" -r=upload_repo',
-                         'conan upload Hello/0.1@pepe/%s --retry 3 --all --force --confirm -r=upload_repo' % channel])
+        self.assertEqual(runner.calls[1],
+                         'conan user pepe -p="password" -r=upload_repo')
+        self.assertIn("conan create", runner.calls[-2])  # Not login again before upload its cached
+        self.assertEqual(runner.calls[-1],
+                         "conan upload Hello/0.1@pepe/%s --retry 3 --all --force --confirm "
+                         "-r=upload_repo" % channel)
 
         runner = MockRunner()
         builder = ConanMultiPackager(username="pepe", channel="testing",
@@ -407,11 +431,26 @@ class AppTest(unittest.TestCase):
                                      apple_clang_versions=[],
                                      runner=runner,
                                      remotes="otherurl",
-                                     platform_info=PlatformInfoMock(),
-                                     check_credentials_before=True)
+                                     platform_info=PlatformInfoMock())
         builder.add_common_builds()
         builder.run()
 
         # When upload is not required, credentials verification must be avoided
         self.assertFalse('conan user pepe -p="password" -r=upload_repo' in runner.calls)
         self.assertFalse('conan upload Hello/0.1@pepe/%s --retry 3 --all --force --confirm -r=upload_repo' % channel in runner.calls)
+
+        # If we skip the credentials check, the login will be performed just before the upload
+        builder = ConanMultiPackager(username="pepe", channel="testing",
+                                     reference="Hello/0.1", password="password",
+                                     upload="myurl", visual_versions=[], gcc_versions=[],
+                                     apple_clang_versions=[],
+                                     runner=runner,
+                                     platform_info=PlatformInfoMock(),
+                                     skip_check_credentials=True)
+        builder.add_common_builds()
+        builder.run()
+        self.assertEqual(runner.calls[-2],
+                         'conan user pepe -p="password" -r=upload_repo')
+        self.assertEqual(runner.calls[-1],
+                         "conan upload Hello/0.1@pepe/%s --retry 3 --all --force --confirm "
+                         "-r=upload_repo" % channel)


### PR DESCRIPTION
If we expose a `login()` method I think it feels more natural to cache the credentials.
And the parameter can be perfectly opt-out, so I changed the name and behavior.
Take a look and tell me what you think!